### PR TITLE
Colour of icons indicating ... Mobile Issue

### DIFF
--- a/components/filter-components/MapFilters.vue
+++ b/components/filter-components/MapFilters.vue
@@ -53,7 +53,7 @@
                 <p class="text-base witchy-text mr-2">
                     Colour of map icons indicating
                   </p>
-                <div class="h-6 px-1 flex items-center justify-center
+                <div class="px-1 flex items-center justify-center
                             mr-2 border-2 rounded-md text-white text-base
                             bg-slate-500 border-slate-700 font medium">
                     <p>


### PR DESCRIPTION
![image](https://github.com/uoe-dlam/witches/assets/71814229/14ffe40f-6bef-457e-961d-ae76b038392f)
Was displaying like this on mobile devices by removing the set height of the div then it now looks like this.
![image](https://github.com/uoe-dlam/witches/assets/71814229/3bafeef2-24f3-413e-ab34-35c9125ae159)
